### PR TITLE
Regex Path Finding

### DIFF
--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 from tulip import *
 import tulippaths as tp
@@ -41,7 +42,7 @@ class TestPath(TestCase):
     def test_toStringOfTypes(self):
         self.assertTrue(self.path.toStringOfTypes() == 'GC ON, Adherens, CBb4w')
 
-    def test_findConstrainedPaths(self):
+    def test_isInTypeConstraints(self):
         graphFile = '../data/test_one.tlp'
         graph = tlp.loadGraph(graphFile)
 
@@ -59,6 +60,33 @@ class TestPath(TestCase):
                 constrainedEdges = ["Ribbon Synapse", "Adherens"]
                 constrainedNodes = ["CBb3-4i", "GC ON", "CBb4w"]
                 self.assertTrue(path.isInTypeConstraints(constrainedEdges, constrainedNodes))
+
+    def test_isInRegexTypeConstraints(self):
+        graphFile = '../data/test_one.tlp'
+        graph = tlp.loadGraph(graphFile)
+
+        source = tp.utils.getNodeById(176, graph)
+        target = tp.utils.getNodeById(5530, graph)
+
+        pathFinder = tp.PathFinder(graph)
+
+        pathFinder.findPaths(source, target, 2)
+
+        for path in pathFinder.valid:
+            if path.size() < 3:
+                continue
+            else:
+                # Make sure the path satisfies valid regex constraints
+                constrainedEdgeRegexes = [ "R.* Synapse", "Adh[a-z]rens" ]
+                constrainedNodeRegexes = [ "CBb3-[1-9]i", "^GZ?C ON$", "C[A-Z]b4w" ]
+                self.assertTrue(path.isInRegexTypeConstraints(
+                    constrainedEdgeRegexes, constrainedNodeRegexes))
+                # Make sure the path does not satisfy invalid regex constraints
+                constrainedEdgeRegexes = [ "Cthulhu F'taghn", "R'lyeh Synapse" ]
+                constrainedNodeRegexes = [ "^Nyarlathotep$", "^$", "[0-1].*" ]
+                self.assertFalse(path.isInRegexTypeConstraints(
+                    constrainedEdgeRegexes, constrainedNodeRegexes))
+
 
     def test_isSynapticPath(self):
 
@@ -79,3 +107,7 @@ class TestPath(TestCase):
                 self.assertFalse(path.isSynapticPath())
             else:
                 self.assertTrue(False) # Should never get here.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pathFinder.py
+++ b/tests/test_pathFinder.py
@@ -56,6 +56,8 @@ class TestFindPaths(TestCase):
 
         self.assertTrue(len(finder.valid) == 3)
 
+    # TODO this test appears to be ineffective because the PathFinder
+    # finds no paths for some reason
     def test_findConstrainedPaths(self):
         graphFile = '../data/test_one.tlp'
         graph = tlp.loadGraph(graphFile)
@@ -69,6 +71,32 @@ class TestFindPaths(TestCase):
         pathFinder = tp.PathFinder(graph)
 
         pathFinder.findConstrainedPaths(source, constrainedToEdgeTypes, constrainedToNodeTypes)
+
+        for path in pathFinder.valid:
+            self.assertTrue(path.isInTypeConstraints(constrainedToEdgeTypes,
+                                                     constrainedToNodeTypes))
+
+    # TODO this test appears to be ineffective because the PathFinder
+    # finds no paths for some reason
+    def test_findRegexConstrainedPaths(self):
+        graphFile = '../data/test_one.tlp'
+        graph = tlp.loadGraph(graphFile)
+        tp.VERBOSE = True
+        source = tp.utils.getNodeById(176, graph)
+        target = tp.utils.getNodeById(5530, graph)
+
+        constrainedToEdgeTypeRegexes = [".+ Synapse", "^Adhe.+$"]
+        constrainedToNodeTypeRegexes = ["CBb3-.+$", "^GC [ON|OFF]$", "[A-Z]Bb4w"]
+
+        pathFinder = tp.PathFinder(graph)
+
+        pathFinder.findRegexConstrainedPaths(source,
+                                             constrainedToEdgeTypeRegexes,
+                                             constrainedToNodeTypeRegexes)
+
+        for path in pathFinder.valid:
+            self.assertTrue(path.isInRegexTypeConstraints(
+                constrainedToEdgeTypeRegexes, constrainedToNodeTypeRegexes))
 
 
 if __name__ == "__main__":

--- a/tests/test_pathFinder.py
+++ b/tests/test_pathFinder.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 from tulip import *
 import tulippaths as tp
@@ -68,3 +69,7 @@ class TestFindPaths(TestCase):
         pathFinder = tp.PathFinder(graph)
 
         pathFinder.findConstrainedPaths(source, constrainedToEdgeTypes, constrainedToNodeTypes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,10 @@
+import unittest
 from unittest import TestCase
 
 from tulip import *
 import tulippaths as tp
+
+import re
 
 class TestUtils(TestCase):
 
@@ -139,3 +142,51 @@ class TestUtils(TestCase):
 
         for node in nodes:
             self.assertTrue(tp.utils.getNodeType(node, graph) in nodeTypes)
+
+    def test_getNodesByTypeRegex(self):
+        self.file = '../data/test_two.tlp'
+
+        # Test multiple cases by looping through this dictionary.
+        # "regex": num_nodes
+        test_cases = {
+            "^$": 0,
+            "^GAC Aii$": 1,
+            "^GC ON$": 1,
+            "^CBb3-4i$": 2,
+            "^CBb4w$": 1,
+            "^GA?C.*$": 2,
+            "^CBb.*$": 3
+        }
+
+        graph = tlp.loadGraph(self.file)
+
+        for test_regex, expected_results in test_cases.iteritems():
+            nodes = tp.utils.getNodesByTypeRegex(test_regex, graph)
+
+            self.assertTrue(len(nodes) == expected_results)
+            for node in nodes:
+                self.assertTrue(
+                    re.search(re.compile(test_regex),
+                              tp.utils.getNodeType(node, graph)))
+
+    def test_getNodesByTypeRegexes(self):
+        self.file = '../data/test_two.tlp'
+
+        graph = tlp.loadGraph(self.file)
+
+        # Test multiple cases by looping through this dictionary.
+        # "regex,other_regex": num_nodes
+        test_cases = {
+            "^GAC Aii$,^CBb3-4i$": 3,
+            "^GA?C.*$,^CBb3-4i$": 4
+        }
+
+        for test_regex_list, expected_results in test_cases.iteritems():
+            nodeTypeRegexes = test_regex_list.split(',')
+            nodes = tp.utils.getNodesByTypeRegexes(nodeTypeRegexes, graph)
+
+            self.assertTrue(len(nodes) == expected_results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tulippaths/path.py
+++ b/tulippaths/path.py
@@ -1,6 +1,7 @@
 """ Object representing a specific path in a graph - nodes and edges """
 
 import utils as utils
+import re
 
 class Path:
     # TODO: Smarter default constructor.
@@ -40,6 +41,23 @@ class Path:
             node = self.nodes[i]
             nodeType = utils.getNodeType(node, self.graph)
             if constrainedNodes[i] != nodeType:
+                return False
+
+        return True
+
+    def isInRegexTypeConstraints(self, constrainedEdgeRegexes,
+                                 constrainedNodeRegexes):
+
+        for i in range(0, len(self.edges)):
+            edge = self.edges[i]
+            edgeType = utils.getEdgeType(edge, self.graph)
+            if not re.search(re.compile(constrainedEdgeRegexes[i]), edgeType):
+                return False
+
+        for i in range(0, len(self.nodes)):
+            node = self.nodes[i]
+            nodeType = utils.getNodeType(node, self.graph)
+            if not re.search(re.compile(constrainedNodeRegexes[i]), nodeType):
                 return False
 
         return True

--- a/tulippaths/pathFinder.py
+++ b/tulippaths/pathFinder.py
@@ -168,6 +168,21 @@ class PathFinder:
 
         self.valid = matches
 
+    def findRegexConstrainedPaths(self, source, nodeConstraintRegexes,
+                                  edgeConstraintRegexes):
+
+        assert len(self.valid) == 0 and len(self.failed) == 0, 'Warning - called findPaths before being reset'
+
+        self.findAllPaths(source, len(edgeConstraintRegexes))
+
+        matches = []
+
+        for path in self.valid:
+            if path.isInRegexTypeConstraints(edgeConstraintRegexes,
+                                             nodeConstraintRegexes):
+                matches.append(path)
+
+        self.valid = matches
 
     def reset(self):
         self.valid = []

--- a/tulippaths/utils.py
+++ b/tulippaths/utils.py
@@ -1,6 +1,7 @@
 """ Misc utilities for accessing and manipulating tulip graphs """
 
 import tulippaths as tp
+import re
 
 # Returns true if node can be reached from sourceTypes.
 # sourceTypes is a list of node types (strings).
@@ -150,6 +151,26 @@ def getNodesByTypes(types, graph):
     nodes = []
     for nodeType in types:
         nodes += getNodesByType(nodeType, graph)
+    return nodes
+
+# Returns a list of nodes whose type labels contain a sequence matching
+# the specified regular expression. (Corresponds to getNodesByType() but
+# with a regex search)
+def getNodesByTypeRegex(type_regex, graph):
+    nodes = []
+    for node in graph.getNodes():
+        nodeType = getNodeType(node, graph)
+        if re.search(re.compile(type_regex), nodeType):
+            nodes.append(node)
+    return nodes
+
+# Returns a list of nodes whose type labels contain a sequence matching any of
+# the specified regular expressions. (Corresponds to getNodesByTypes() but with
+# a regex searches)
+def getNodesByTypeRegexes(type_regexes, graph):
+    nodes = []
+    for nodeTypeRegex in type_regexes:
+        nodes += getNodesByTypeRegex(nodeTypeRegex, graph)
     return nodes
 
 def getNodeId(node, graph):


### PR DESCRIPTION
I think I implemented all the functions we will need to get the plugin searching for paths using regex-based constraints. Everything is passing unit tests but I noticed a problem in one of your existing unit tests in test_pathFinder.py: the test on the existing findConstrainedPaths() function had no assertions at all, and when I tried to fix this I found that the test doesn't in fact find any paths from the specified data file, so there's nothing to assert. I think this is just a problem with the data file, but it means my unit test for PathFinder.findRegexConstrainedPaths() doesn't really prove anything.